### PR TITLE
add option --limit on "streak:subscription:run"…

### DIFF
--- a/src/Command/RunSubscriptionCommand.php
+++ b/src/Command/RunSubscriptionCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 
@@ -46,6 +47,7 @@ class RunSubscriptionCommand extends Command
         $this->setDefinition([
             new InputArgument('subscription-type', InputArgument::REQUIRED, 'Specify subscription type'),
             new InputArgument('subscription-id', InputArgument::REQUIRED, 'Specify subscription id'),
+            new InputOption('limit', 'l', InputOption::VALUE_OPTIONAL, 'Maximum number of events subscription can listen to', 1000),
         ]);
     }
 
@@ -58,6 +60,8 @@ class RunSubscriptionCommand extends Command
 
             return;
         }
+
+        $limit = (int) $input->getOption('limit');
 
         ProgressBar::setFormatDefinition('custom', 'Subscription <fg=blue>%subscription_type%</>(<fg=cyan>%subscription_id%</>) processed <fg=yellow>%current%</> events in <fg=magenta>%elapsed%</>.');
 
@@ -74,7 +78,7 @@ class RunSubscriptionCommand extends Command
         $progress->display();
 
         try {
-            foreach ($subscription->subscribeTo($this->store) as $event) {
+            foreach ($subscription->subscribeTo($this->store, $limit) as $event) {
                 $progress->advance();
             }
         } finally {

--- a/src/Tests/Command/RunSubscriptionCommandTest.php
+++ b/src/Tests/Command/RunSubscriptionCommandTest.php
@@ -106,12 +106,39 @@ class RunSubscriptionCommandTest extends TestCase
         $this->subscription1
             ->expects($this->once())
             ->method('subscribeTo')
-            ->with($this->store)
+            ->with($this->store, 1000) // 1000 is default --limit
             ->willReturn([$this->event1, $this->event2])
         ;
 
         $command = new RunSubscriptionCommand($this->repository, $this->store);
         $command->run(new ArrayInput(['subscription-type' => 'Streak\\StreakBundle\\Tests\\Command\\RunSubscriptionCommandTest\\SubscriptionId1', 'subscription-id' => 'EC2BE294-C07A-4198-A159-4551686F14F9']), $this->output);
+
+        $expected =
+            "Subscription Streak\StreakBundle\Tests\Command\RunSubscriptionCommandTest\SubscriptionId1(EC2BE294-C07A-4198-A159-4551686F14F9) processed    0 events in < 1 sec.".
+            self::TERMINAL_CLEAR_LINE.
+            "Subscription Streak\StreakBundle\Tests\Command\RunSubscriptionCommandTest\SubscriptionId1(EC2BE294-C07A-4198-A159-4551686F14F9) processed    2 events in < 1 sec."
+        ;
+        $this->assertEquals($expected, $this->output->output);
+    }
+
+    public function testCommandWithLimit()
+    {
+        $this->repository
+            ->expects($this->once())
+            ->method('find')
+            ->with(SubscriptionId1::fromString('EC2BE294-C07A-4198-A159-4551686F14F9'))
+            ->willReturn($this->subscription1)
+        ;
+
+        $this->subscription1
+            ->expects($this->once())
+            ->method('subscribeTo')
+            ->with($this->store, 763723)
+            ->willReturn([$this->event1, $this->event2])
+        ;
+
+        $command = new RunSubscriptionCommand($this->repository, $this->store);
+        $command->run(new ArrayInput(['subscription-type' => 'Streak\\StreakBundle\\Tests\\Command\\RunSubscriptionCommandTest\\SubscriptionId1', 'subscription-id' => 'EC2BE294-C07A-4198-A159-4551686F14F9', '--limit' => 763723]), $this->output);
 
         $expected =
             "Subscription Streak\StreakBundle\Tests\Command\RunSubscriptionCommandTest\SubscriptionId1(EC2BE294-C07A-4198-A159-4551686F14F9) processed    0 events in < 1 sec.".


### PR DESCRIPTION
… to specify maximum number of events subscription can listen to when subscribed to the event store.